### PR TITLE
fix correct mask in price field

### DIFF
--- a/src/screens/clients/columns.tsx
+++ b/src/screens/clients/columns.tsx
@@ -43,7 +43,7 @@ export const columns = (setClient: React.Dispatch<React.SetStateAction<Client[]>
         },
         cell: ({ row }) => {
             return (
-                <p className='text-black dark:text-white text-[14.5px]'>{row.original.budget.toFixed(2)}</p>
+                <p className='text-black dark:text-white text-[14.5px]'>R${row.original.budget.toFixed(2)}</p>
             )
         }
     },

--- a/src/screens/services/columns.tsx
+++ b/src/screens/services/columns.tsx
@@ -53,12 +53,12 @@ export const columns = (setService: React.Dispatch<React.SetStateAction<Service[
         accessorKey: 'price',
         header: () => {
             return (
-                <p className='text-black dark:text-white text-[12px] font-extrabold text-xs uppercase'>Valor R$</p>
+                <p className='text-black dark:text-white text-[12px] font-extrabold text-xs uppercase'>Custo de Serviço</p>
             )
         },
         cell: ({ row }) => {
             return (
-                <p className='text-black dark:text-white text-[14.5px]'>{parseFloat(row.original.price).toFixed(2)}</p>
+                <p className='text-black dark:text-white text-[14.5px]'>R${parseFloat(row.original.price).toFixed(2)}</p>
             )
         }
     },


### PR DESCRIPTION
1 - Adicionada a máscara no campo "Price":
A máscara foi ajustada para aceitar valores com vírgula, ponto e utilizando o prefixo "R$".

2 - Adicionada a validação do campo "Price" como string:
O campo "Price" foi ajustado para ser do tipo string, com validação que exige no mínimo 7 dígitos incluindo R$ e o espaço.

3 - Adicionado o prefixo "R$" na coluna de "Service" e "Client":
Na listagem de valores, o prefixo "R$" foi adicionado, que antes eram exibidos apenas como 80,00. Agora, os valores aparecerão como R$80,00 nas colunas de "Service" e "Client".